### PR TITLE
fix: limit product access to seller organizations

### DIFF
--- a/app/Http/Controllers/Api/OrganizationController.php
+++ b/app/Http/Controllers/Api/OrganizationController.php
@@ -154,6 +154,7 @@ class OrganizationController extends Controller
             ->select(DB::raw('SUM(sb.quantity) as balance, sb.product_id, sb.organization_id, p.molecular_name, p.brand_name, p.pack_size, p.strength'))
             ->join('tbl_product AS p', 'p.id', '=', 'sb.product_id')
             ->where('sb.organization_id', $id)
+            ->where('p.organization_id', $id)
             ->groupBy('sb.product_id', 'sb.organization_id', 'p.molecular_name', 'p.brand_name', 'p.pack_size', 'p.strength')
             ->orderBy('p.molecular_name', 'DESC')
             ->get();
@@ -204,9 +205,9 @@ class OrganizationController extends Controller
      */
     public function getOrganizationProductPromos($id)
     {
-        $productpromos = ProductPromo::with(['product_now' => function ($query) use ($id) {
+        $productpromos = ProductPromo::with(['product_now', 'product_now.product', 'product_now.organization', 'product_now.user', 'offer'])->whereHas('product_now', function ($query) use ($id) {
             $query->where('organization_id', $id);
-        }, 'product_now.product', 'product_now.organization', 'product_now.user', 'offer'])->get();
+        })->get();
         return response()->json($productpromos);
     }
 
@@ -218,9 +219,9 @@ class OrganizationController extends Controller
      */
     public function getOrganizationProductDeals($id)
     {
-        $productdeals = ProductDeal::with(['product_now' => function ($query) use ($id) {
+        $productdeals = ProductDeal::with(['product_now', 'product_now.product', 'product_now.organization', 'product_now.user', 'offer'])->whereHas('product_now', function ($query) use ($id) {
             $query->where('organization_id', $id);
-        }, 'product_now.product', 'product_now.organization', 'product_now.user', 'offer'])->get();
+        })->get();
         return response()->json($productdeals);
     }
 
@@ -258,7 +259,7 @@ class OrganizationController extends Controller
      */
     public function getOrganizationProducts($id)
     {
-        $organization_products = Product::with(['organization', 'product_category'])->where('organization_id', $id)->limit(100)->get();
+        $organization_products = Product::with(['organization', 'product_category'])->where('organization_id', $id)->orderBy('molecular_name', 'ASC')->get();
         return response()->json($organization_products);
     }
 

--- a/app/Http/Controllers/Api/ProductController.php
+++ b/app/Http/Controllers/Api/ProductController.php
@@ -15,7 +15,7 @@ class ProductController extends Controller
      */
     public function index()
     {
-        $products = Product::with('product_category', 'organization')->orderBy('molecular_name', 'ASC')->limit(100)->get();
+        $products = Product::with('product_category', 'organization')->orderBy('molecular_name', 'ASC')->get();
         return response()->json($products);
     }
 

--- a/app/Http/Controllers/Seller/SellerController.php
+++ b/app/Http/Controllers/Seller/SellerController.php
@@ -775,14 +775,15 @@ class SellerController extends MyController
     public function getDropDownData($token = null, $resource = null)
     {
         $dropdown_data = [];
+        $organization_id = session()->get('organization_id');
         $data_sources = [
-            'offers' => ['organizations'],
-            'stockbalances' => ['products', 'stocktypes']
+            'offers' => ['organizations' => 'organizations'],
+            'stockbalances' => ['products' => 'organization/' . $organization_id . '/products', 'stocktypes' => 'stocktypes']
         ];
 
         if ($token !== null && $resource !== null) {
-            foreach ($data_sources[$resource] as $data_source) {
-                $dropdown_data[str_replace('-', '_', $data_source)] = $this->getResourceData($token, $data_source);
+            foreach ($data_sources[$resource] as $data_ref => $data_source) {
+                $dropdown_data[str_replace('-', '_', $data_ref)] = $this->getResourceData($token, $data_source);
             }
         }
 


### PR DESCRIPTION
-removed limits to /products and /organization/{id}/products
-show stockbalances for organization products
-show only organization products when managing stocks
-show only organization stocks when managing pricelists